### PR TITLE
fix(style): some minors fixes

### DIFF
--- a/src/components/GlistenDashboard.vue
+++ b/src/components/GlistenDashboard.vue
@@ -1,19 +1,22 @@
 <template>
   <v-row>
-    <v-col cols="3 justify-center">
+    <v-col cols="3" justify-center>
       <filters
         :startDate.sync="startDate"
         :endDate.sync="endDate"
         :availableApplications="availableApplications"
         :filteredApplications.sync="filteredApplications"
       />
-      <csat-score-card :ratings="ratings" />
-      <nps-details-card :ratings="ratings" />
-      <nps-score-gauge :ratings="ratings" />
+      <csat-score-card v-if="ratings.length > 0" :ratings="ratings" />
+      <nps-details-card v-if="ratings.length > 0" :ratings="ratings" />
+      <nps-score-gauge v-if="ratings.length > 0" :ratings="ratings" />
     </v-col>
-    <v-col cols="9">
-      <nps-line-chart :timedRatings="timedRatings" timePeriod="days" displayDateFormat="LL" />
-      <nps-bar-chart :timedRatings="timedRatings" timePeriod="days" displayDateFormat="LL" />
+    <v-col cols="9" v-if="timedRatings.length > 0">
+      <nps-line-chart :timedRatings="timedRatings" timePeriod="weeks" displayDateFormat="LL" />
+      <nps-bar-chart :timedRatings="timedRatings" timePeriod="weeks" displayDateFormat="LL" />
+    </v-col>
+    <v-col cols="9" v-else>
+      <div class="no-data-label">No data</div>
     </v-col>
 
     <v-col cols="12">
@@ -215,3 +218,12 @@ export default class GlistenDashboard extends Vue {
   }
 }
 </script>
+
+<style scoped>
+.no-data-label {
+  display: flex;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+}
+</style>

--- a/src/components/NpsBarChart.vue
+++ b/src/components/NpsBarChart.vue
@@ -107,6 +107,9 @@ export default class NpsBarChart extends Vue {
 
   private get chartOptions(): ApexOptions {
     return {
+      title: {
+        text: 'Responses (week over week) ',
+      },
       chart: {
         type: 'bar',
         stacked: true,

--- a/src/components/NpsLineChart.vue
+++ b/src/components/NpsLineChart.vue
@@ -101,6 +101,9 @@ export default class NpsLineChart extends Vue {
 
   private get chartOptions(): ApexOptions {
     return {
+      title: {
+        text: 'Net Promoter Score (week over week) ',
+      },
       chart: {
         type: 'line',
         stacked: true,


### PR DESCRIPTION
Fixes : 

[X] Both timelines should show the data grouped by weeks as designed in the mockup. Daily those charts will not be moving enough
[X] Missing the title of both timelines: Net Promoter Score (week over week) and Responses (week over week)