### PR TITLE
fix(glisten-dashboard): crash of dashboard when data.status, data.feedback or data.rating is incorrect

### DIFF
--- a/src/components/GlistenCsat.vue
+++ b/src/components/GlistenCsat.vue
@@ -122,26 +122,30 @@ export default class GlistenCsat extends Vue {
     previous: FeedbackQueryResult,
     update: { subscriptionData: { data: FeedbackSubcriptionResult } },
   ): FeedbackQueryResult {
-    const HasTypename = z.object({ __typename: z.string() });
-    const Schema = FeedbackSchema.merge(HasTypename); // validates data but keep property __typename that is useful for caching purpose
+    try {
+      const HasTypename = z.object({ __typename: z.string() });
+      const Schema = FeedbackSchema.merge(HasTypename); // validates data but keep property __typename that is useful for caching purpose
 
-    const feedback = Schema.parse(update.subscriptionData.data.feedbackAdded);
-    const existingFeedbackIndex = previous.feedbacks.findIndex(
-      (f: IFeedback) => feedback._id === f._id,
-    );
+      const feedback = Schema.parse(update.subscriptionData.data.feedbackAdded);
+      const existingFeedbackIndex = previous.feedbacks.findIndex(
+        (f: IFeedback) => feedback._id === f._id,
+      );
 
-    // If the whisp is already in the collection we update it
-    // Else we add it to the top
-    if (existingFeedbackIndex >= 0) {
-      return {
-        feedbacks: Object.assign([], previous.feedbacks, {
-          [existingFeedbackIndex]: feedback,
-        }),
-      };
-    }
+      // If the whisp is already in the collection we update it
+      // Else we add it to the top
+      if (existingFeedbackIndex >= 0) {
+        return {
+          feedbacks: Object.assign([], previous.feedbacks, {
+            [existingFeedbackIndex]: feedback,
+          }),
+        };
+      }
 
-    if (dayjs(feedback.timestamp).isBetween(this.startDate, this.endDate, 'days', '[]')) {
-      return { feedbacks: [feedback, ...previous.feedbacks] };
+      if (dayjs(feedback.timestamp).isBetween(this.startDate, this.endDate, 'days', '[]')) {
+        return { feedbacks: [feedback, ...previous.feedbacks] };
+      }
+    } catch (err) {
+      console.log('Invalid Data received.');
     }
 
     return previous;

--- a/src/components/GlistenCsat.vue
+++ b/src/components/GlistenCsat.vue
@@ -80,7 +80,13 @@ export default class GlistenCsat extends Vue {
   private feedbacks: IFeedback[] = [];
 
   private get queryFilter(): Partial<IFeedback> {
-    let filter: any = { type: WHISP_FEEDBACK_TYPE };
+    let filter: any = {
+      type: WHISP_FEEDBACK_TYPE,
+      data: { $ne: null },
+      'data.status': { $in: ['ACTION_NEEDED', 'ACTION_DONE', 'NO_ACTION_NEEDED'] },
+      'data.feedback': { $ne: null },
+      'data.rating': { $gte: 0, $lte: 5 },
+    };
 
     if (this.startDate && this.endDate) {
       const startOfDay = (date: Date) =>

--- a/src/components/GlistenDashboard.vue
+++ b/src/components/GlistenDashboard.vue
@@ -67,11 +67,16 @@ import {
   UpdateWhispVariables,
   UpdateWhispResult,
 } from '@/graphql/queries/whispQueries';
-import { IFeedback, FeedbackStatus, WHISP_FEEDBACK_TYPE, WHISP_GQL_CLIENT } from '@/types/whisps';
+import {
+  IFeedback,
+  FeedbackStatus,
+  WHISP_FEEDBACK_TYPE,
+  WHISP_GQL_CLIENT,
+  FeedbackSchema,
+} from '@/types/whisps';
 import { chain } from 'lodash';
 import dayjs from 'dayjs';
 import { SmartQuery, SubscribeToMore } from 'vue-apollo-decorators';
-import { FeedbackSchema } from '@/types/whisps';
 import * as z from 'zod';
 import { VCard } from 'vuetify/lib';
 
@@ -136,7 +141,13 @@ export default class GlistenDashboard extends Vue {
   }
 
   private get queryFilter(): Partial<IFeedback> {
-    let filter: any = { type: WHISP_FEEDBACK_TYPE, data: { "$ne": null } };
+    let filter: any = {
+      type: WHISP_FEEDBACK_TYPE,
+      data: { $ne: null },
+      'data.status': { $in: ['ACTION_NEEDED', 'ACTION_DONE', 'NO_ACTION_NEEDED'] },
+      'data.feedback': { $ne: null },
+      'data.rating': { $gte: 0, $lte: 5 },
+    };
 
     if (this.startDate && this.endDate) {
       const startOfDay = (date: Date) =>
@@ -189,7 +200,6 @@ export default class GlistenDashboard extends Vue {
       return {
         filter: {
           type: WHISP_FEEDBACK_TYPE,
-          data: { "$ne": null },
         },
       };
     },

--- a/src/components/GlistenDashboard.vue
+++ b/src/components/GlistenDashboard.vue
@@ -204,8 +204,6 @@ export default class GlistenDashboard extends Vue {
       };
     },
     updateQuery(previous, options) {
-      console.log(previous);
-      console.log(options);
       return this.updateFeedbacksOnSubscriptionEvent(previous, options);
     },
   })


### PR DESCRIPTION
In this MR: 
- we fix some more errors on null properties of the data object.

**Moreover complex filtering on subscription seems not possible and broke the feedbacks refresh through websocket**.

for example this example doesn't work:
```
  @SubscribeToMore<
    GlistenDashboard,
    FeedbackQueryResult,
    FeedbackSubscriptionVariables,
    FeedbackSubcriptionResult
  >({
    document: SUBCRIPTION_FEEDBACKS,
    variables() {
      return {
        filter: {
          type: WHISP_FEEDBACK_TYPE,
          data: { $ne: null },
          'data.status': { $in: ['ACTION_NEEDED', 'ACTION_DONE', 'NO_ACTION_NEEDED'] },
          'data.feedback': { $ne: null },
          'data.rating': { $gte: 0, $lte: 5 },
        },
      };
    },
    updateQuery(previous, options) {
      return this.updateFeedbacksOnSubscriptionEvent(previous, options);
    },
  })

```

In order to avoid error on incorrect data (for the feedbacks refresh through websocket), I've added a try catch to properly catch the error and log a message:
![Screenshot 2022-03-03 at 11 27 35](https://user-images.githubusercontent.com/36277587/156547736-3c0d7930-d2d6-4662-a8f0-e5e4d4296784.png)

Instead of:
![Screenshot 2022-03-03 at 11 23 58](https://user-images.githubusercontent.com/36277587/156547784-e71942a2-c2d1-4e0b-ad9d-068baeb12060.png)

I've also fixed **GlistenCsat**.


Closes FND-1179