### PR TITLE
fix: export apollo provider function

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,8 @@ Then configure vue-apollo to connect your project to [Whispr](https://github.com
 
 ```javascript
 import Vue from 'vue';
-import { apolloProvider } from '@sanofi-iadc/glisten/graphql/apollo';
 import VueApollo from 'vue-apollo';
-import Glisten, { GlistenClient, GlistenDashboard } from '@sanofi-iadc/glisten';
+import Glisten, { GlistenClient, GlistenDashboard, ApolloProvider } from '@sanofi-iadc/glisten';
 
 Vue.component('GlistenClient', GlistenClient); // this is not mandatory if you need to use only one component
 Vue.component('GlistenDashboard', GlistenDashboard);
@@ -50,7 +49,7 @@ Vue.use(Vuetify);
 
 new Vue({
   vuetify,
-  apolloProvider: apolloProvider(
+  apolloProvider: ApolloProvider(
     process.env.VUE_APP_WHISPR_API_HTTP_URL,
     process.env.VUE_APP_WHISPR_API_WS_URL,
   ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sanofi-iadc/glisten",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sanofi-iadc/glisten",
-      "version": "1.1.6",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@vuepress/plugin-back-to-top": "^1.8.2",

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -14,6 +14,8 @@ export { default as GlistenClient } from '@/components/GlistenClient.vue';
 export { default as GlistenDashboard } from '@/components/GlistenDashboard.vue';
 export { default as GlistenCsat } from '@/components/GlistenCsat.vue';
 
+export { apolloProvider as ApolloProvider } from '@/graphql/apollo';
+
 const Plugin = {
   install: (vue: VueConstructor, options: any) => {
     Vue.prototype.dayjs = dayjs;


### PR DESCRIPTION
### Discovered problem:

An issue was found while trying to use `apolloProvider` as explained in the README:
`WHISP_GQL_CLIENT` import, used by the function, is not accessible because not part of the packaged code.

### Code change explanations

Adding the `apolloProvider` function to the list of exported members.
This allows the built version to be packaged with all related code to this function.

The README has also been updated to reflect the change on how to import the function.
