### PR TITLE
fix: add apollo provider to typings definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,11 @@
 import { VueConstructor } from 'vue';
+import VueApollo from 'vue-apollo';
 
 export const GlistenClient: VueConstructor;
 export const GlistenDashboard: VueConstructor;
+export const GlistenCsat: VueConstructor;
+
+export const ApolloProvider: (httpURL: string, wsURL: string) => VueApollo;
 
 declare module '@sanofi-iadc/glisten' {
   export function install(vue: VueConstructor, options: any): void;


### PR DESCRIPTION
### Discovered problem:

After exposing the `apolloProvider` from the library, the update of the typings definition (`index.d.ts`) was missed.
Also, the list of exported members between `exports.ts` and the typed definition is not aligned.

### Code change explanations

Aligning the list of exported members between `exports.ts` and the typed definition `index.d.ts`.
- Adding the `ApolloProvider` to the list of members in the typings definition.
- Adding the GlistenCsat component to the list of members in the typings definition.
