### PR TITLE
fix: action required field gui refresh

### DIFF
--- a/src/components/GlistenClient.vue
+++ b/src/components/GlistenClient.vue
@@ -243,6 +243,7 @@ export default class GlistenClient extends Vue {
           this.snackbarColor = 'error';
           this.snackbarDisplayed = true;
         }
+        this.actionRequired = false;
       });
 
     this.$emit('close', this.glistenWhisp);


### PR DESCRIPTION
Right now the the gui doesn't get correctly updated when you are trying to send a second request with the glisten client. This only affects the "action required" option. When the action required switch is true on the first request the gui on the second request also has the true option pre selected. This however doesn't reflect the current state of the v-model which is false at that time. This leads to the bug that the second request sends action-required: false even though the user thinks he has selected true.
This fix ensures that the field will also be update in the gui to false.